### PR TITLE
Remove Error handling

### DIFF
--- a/grpcclient/aes_client.go
+++ b/grpcclient/aes_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math/rand"
 
-	log "github.com/sirupsen/logrus"
 	pb "github.com/vhive-serverless/vSwarm-proto/proto/aes"
 )
 
@@ -49,16 +48,19 @@ type AesClient struct {
 	client pb.AesClient
 }
 
-func (c *AesClient) Init(ctx context.Context, ip, port string) {
-	log.Printf("Connect to: %s:%s\n", ip, port)
-	c.Connect(ctx, ip, port)
+func (c *AesClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewAesClient(c.conn)
+	return nil
 }
 
-func (c *AesClient) Request(ctx context.Context, req Input) string {
+func (c *AesClient) Request(ctx context.Context, req Input) (string, error) {
 	r, err := c.client.ShowEncryption(ctx, &pb.PlainTextMessage{PlaintextMessage: req.Value})
 	if err != nil {
-		log.Fatalf("could not greet: %v", err)
+		return "", err
 	}
-	return r.GetEncryptionInfo()
+	return r.GetEncryptionInfo(), nil
 }

--- a/grpcclient/auth_client.go
+++ b/grpcclient/auth_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math/rand"
 
-	log "github.com/sirupsen/logrus"
 	pb "github.com/vhive-serverless/vSwarm-proto/proto/auth"
 )
 
@@ -38,16 +37,20 @@ type AuthClient struct {
 	client pb.GreeterClient
 }
 
-func (c *AuthClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *AuthClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewGreeterClient(c.conn)
+	return nil
 }
 
-func (c *AuthClient) Request(ctx context.Context, req Input) string {
+func (c *AuthClient) Request(ctx context.Context, req Input) (string, error) {
 	var authMessage = req.Value
 	r, err := c.client.SayHello(ctx, &pb.HelloRequest{Name: authMessage})
 	if err != nil {
-		log.Fatalf("could not greet: %v", err)
+		return "", err
 	}
-	return r.GetMessage()
+	return r.GetMessage(), nil
 }

--- a/grpcclient/fibonacci_client.go
+++ b/grpcclient/fibonacci_client.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 
 	pb "github.com/vhive-serverless/vSwarm-proto/proto/fibonacci"
-	log "github.com/sirupsen/logrus"
 )
 
 type FibonacciGenerator struct {
@@ -37,16 +36,20 @@ type FibonacciClient struct {
 	client pb.GreeterClient
 }
 
-func (c *FibonacciClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *FibonacciClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewGreeterClient(c.conn)
+	return nil
 }
 
-func (c *FibonacciClient) Request(ctx context.Context, req Input) string {
+func (c *FibonacciClient) Request(ctx context.Context, req Input) (string, error) {
 	var fibonacciMessage = req.Value
 	r, err := c.client.SayHello(ctx, &pb.HelloRequest{Name: fibonacciMessage})
 	if err != nil {
-		log.Fatalf("could not greet: %v", err)
+		return "", err
 	}
-	return r.GetMessage()
+	return r.GetMessage(), nil
 }

--- a/grpcclient/gptj_client.go
+++ b/grpcclient/gptj_client.go
@@ -6,7 +6,6 @@ import (
 	pb "github.com/vhive-serverless/vSwarm-proto/proto/gptj"
 )
 
-
 type GptJGenerator struct {
 	GeneratorBase
 }
@@ -33,17 +32,20 @@ func (c *GptJClient) GetGenerator() Generator {
 	return new(GptJGenerator)
 }
 
-
-func (c *GptJClient) Init(ctx context.Context, ip, port string) {
+func (c *GptJClient) Init(ctx context.Context, ip, port string) error {
 	log.Printf("Connect to: %s:%s\n", ip, port)
-	c.Connect(ctx, ip, port)
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewGptJBenchmarkClient(c.conn)
+	return nil
 }
 
-func (c *GptJClient) Request(ctx context.Context, req Input) string {
+func (c *GptJClient) Request(ctx context.Context, req Input) (string, error) {
 	r, err := c.client.GetBenchmark(ctx, &pb.GptJBenchmarkRequest{Regenerate: req.Value})
 	if err != nil {
-		log.Fatalf("could not greet: %v", err)
+		return "", err
 	}
-	return r.GetLatencyInfo();
+	return r.GetLatencyInfo(), nil
 }

--- a/grpcclient/grpcclient.go
+++ b/grpcclient/grpcclient.go
@@ -77,8 +77,8 @@ func (s *GeneratorBase) Decrement() int {
 // ------ gRPC Client interface ------
 // Every client must implement this interface
 type GrpcClient interface {
-	Init(ctx context.Context, ip, port string)
-	Request(ctx context.Context, req Input) string
+	Init(ctx context.Context, ip, port string) error
+	Request(ctx context.Context, req Input) (string, error)
 	Close()
 	GetGenerator() Generator
 }
@@ -90,12 +90,12 @@ type ClientBase struct {
 	conn *grpc.ClientConn
 }
 
-func (c *ClientBase) Connect(ctx context.Context, ip, port string) {
+func (c *ClientBase) Connect(ctx context.Context, ip, port string) error {
 	c.ip = ip
 	c.port = port
 	// Connect to the given address
 	address := fmt.Sprintf("%s:%s", c.ip, c.port)
-	log.Debug("Connect to ", address)
+	log.Println("Connect to ", address)
 	var conn *grpc.ClientConn
 	var err error
 	if tracing.IsTracingEnabled() {
@@ -110,10 +110,11 @@ func (c *ClientBase) Connect(ctx context.Context, ip, port string) {
 			log.Fields{
 				"event": "Connecting to benchmark server",
 				"key":   err,
-			}).Fatal("Failed to connect.")
+			})
+		return err
 	}
 	c.conn = conn
-
+	return nil
 }
 
 func (c *ClientBase) Close() {

--- a/grpcclient/helloworld_client.go
+++ b/grpcclient/helloworld_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	pb "github.com/vhive-serverless/vSwarm-proto/proto/helloworld"
-	log "github.com/sirupsen/logrus"
 )
 
 // type HelloWorldGenerator struct {
@@ -58,15 +57,19 @@ type HelloWorldClient struct {
 	client pb.GreeterClient
 }
 
-func (c *HelloWorldClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *HelloWorldClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewGreeterClient(c.conn)
+	return nil
 }
 
-func (c *HelloWorldClient) Request(ctx context.Context, req Input) string {
+func (c *HelloWorldClient) Request(ctx context.Context, req Input) (string, error) {
 	r, err := c.client.SayHello(ctx, &pb.HelloRequest{Name: req.Value})
 	if err != nil {
-		log.Fatalf("could not greet: %v", err)
+		return "", err
 	}
-	return r.GetMessage()
+	return r.GetMessage(), nil
 }

--- a/grpcclient/hipstershop_clients.go
+++ b/grpcclient/hipstershop_clients.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
-	pb "github.com/vhive-serverless/vSwarm-proto/proto/hipstershop"
 	log "github.com/sirupsen/logrus"
+	pb "github.com/vhive-serverless/vSwarm-proto/proto/hipstershop"
 )
 
 var (
@@ -63,20 +63,22 @@ var (
 	defProductId2 = "LS4PSXUNUM"
 )
 
-//
 // ------- Ad Service --------
-//
 type ShopAdServiceClient struct {
 	ClientBase
 	client pb.AdServiceClient
 }
 
-func (c *ShopAdServiceClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *ShopAdServiceClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewAdServiceClient(c.conn)
+	return nil
 }
 
-func (c *ShopAdServiceClient) Request(ctx context.Context, req Input) string {
+func (c *ShopAdServiceClient) Request(ctx context.Context, req Input) (string, error) {
 
 	payload := req.Value
 	// Create a default forward request
@@ -86,12 +88,12 @@ func (c *ShopAdServiceClient) Request(ctx context.Context, req Input) string {
 
 	fw_res, err := c.client.GetAds(ctx, &fw_req)
 	if err != nil {
-		log.Fatalf("Fail to invoke Ad service: %v", err)
+		return "", err
 	}
 
 	msg := fmt.Sprintf("%+v", fw_res)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type ShopAdServiceGenerator struct {
@@ -106,20 +108,22 @@ func (c *ShopAdServiceClient) GetGenerator() Generator {
 	return new(ShopAdServiceGenerator)
 }
 
-//
 // ------- Cart Service --------
-//
 type ShopCartServiceClient struct {
 	ClientBase
 	client pb.CartServiceClient
 }
 
-func (c *ShopCartServiceClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *ShopCartServiceClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewCartServiceClient(c.conn)
+	return nil
 }
 
-func (c *ShopCartServiceClient) Request(ctx context.Context, req Input) string {
+func (c *ShopCartServiceClient) Request(ctx context.Context, req Input) (string, error) {
 
 	fw_method := req.Method
 	payload := req.Value
@@ -158,12 +162,12 @@ func (c *ShopCartServiceClient) Request(ctx context.Context, req Input) string {
 
 	}
 	if err != nil {
-		log.Fatalf("Fail to invoke Cart service: %v", err)
+		return "", err
 	}
 
 	msg = fmt.Sprintf("method: %s, %s", fw_method, msg)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type ShopCartServiceGenerator struct {
@@ -178,20 +182,22 @@ func (c *ShopCartServiceClient) GetGenerator() Generator {
 	return new(ShopCartServiceGenerator)
 }
 
-//
 // ------- Checkout Service --------
-//
 type ShopCheckoutServiceClient struct {
 	ClientBase
 	client pb.CheckoutServiceClient
 }
 
-func (c *ShopCheckoutServiceClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *ShopCheckoutServiceClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewCheckoutServiceClient(c.conn)
+	return nil
 }
 
-func (c *ShopCheckoutServiceClient) Request(ctx context.Context, req Input) string {
+func (c *ShopCheckoutServiceClient) Request(ctx context.Context, req Input) (string, error) {
 
 	// Pass on to the real service function
 	payload := req.Value
@@ -207,12 +213,12 @@ func (c *ShopCheckoutServiceClient) Request(ctx context.Context, req Input) stri
 
 	fw_res, err := c.client.PlaceOrder(ctx, &fw_req)
 	if err != nil {
-		log.Fatalf("Fail to invoke Checkout service: %v", err)
+		return "", err
 	}
 
 	msg := fmt.Sprintf("%+v", fw_res)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type ShopCheckoutServiceGenerator struct {
@@ -227,20 +233,22 @@ func (c *ShopCheckoutServiceClient) GetGenerator() Generator {
 	return new(ShopCheckoutServiceGenerator)
 }
 
-//
 // ------- Currency Service --------
-//
 type ShopCurrencyServiceClient struct {
 	ClientBase
 	client pb.CurrencyServiceClient
 }
 
-func (c *ShopCurrencyServiceClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *ShopCurrencyServiceClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewCurrencyServiceClient(c.conn)
+	return nil
 }
 
-func (c *ShopCurrencyServiceClient) Request(ctx context.Context, req Input) string {
+func (c *ShopCurrencyServiceClient) Request(ctx context.Context, req Input) (string, error) {
 
 	fw_method, payload := req.Method, req.Value
 	// Pass on to the real service function
@@ -271,12 +279,12 @@ func (c *ShopCurrencyServiceClient) Request(ctx context.Context, req Input) stri
 		log.Fatalf("Failed to understand requested method: %s", fw_method)
 	}
 	if err != nil {
-		log.Fatalf("Fail to invoke Currency service: %v", err)
+		return "", err
 	}
 
 	msg = fmt.Sprintf("method: %s, %s", fw_method, msg)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type ShopCurrencyServiceGenerator struct {
@@ -291,20 +299,22 @@ func (c *ShopCurrencyServiceClient) GetGenerator() Generator {
 	return new(ShopCurrencyServiceGenerator)
 }
 
-//
 // ------- Email Service --------
-//
 type ShopEmailServiceClient struct {
 	ClientBase
 	client pb.EmailServiceClient
 }
 
-func (c *ShopEmailServiceClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *ShopEmailServiceClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewEmailServiceClient(c.conn)
+	return nil
 }
 
-func (c *ShopEmailServiceClient) Request(ctx context.Context, req Input) string {
+func (c *ShopEmailServiceClient) Request(ctx context.Context, req Input) (string, error) {
 
 	// Pass on to the real service function
 	// _, payload := getMethodPayload(req)
@@ -317,12 +327,11 @@ func (c *ShopEmailServiceClient) Request(ctx context.Context, req Input) string 
 
 	fw_res, err := c.client.SendOrderConfirmation(ctx, &fw_req)
 	if err != nil {
-		log.Fatalf("Fail to invoke Email service: %v", err)
+		return "", err
 	}
-
 	msg := fmt.Sprintf("%+v", fw_res)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 
 }
 
@@ -338,20 +347,22 @@ func (c *ShopEmailServiceClient) GetGenerator() Generator {
 	return new(ShopEmailServiceGenerator)
 }
 
-//
 // ------- Payment Service --------
-//
 type ShopPaymentServiceClient struct {
 	ClientBase
 	client pb.PaymentServiceClient
 }
 
-func (c *ShopPaymentServiceClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *ShopPaymentServiceClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewPaymentServiceClient(c.conn)
+	return nil
 }
 
-func (c *ShopPaymentServiceClient) Request(ctx context.Context, req Input) string {
+func (c *ShopPaymentServiceClient) Request(ctx context.Context, req Input) (string, error) {
 
 	payload := req.Value
 	// Create a default forward request
@@ -366,12 +377,12 @@ func (c *ShopPaymentServiceClient) Request(ctx context.Context, req Input) strin
 
 	fw_res, err := c.client.Charge(ctx, &fw_req)
 	if err != nil {
-		log.Fatalf("Fail to invoke Payment service: %v", err)
+		return "", err
 	}
 
 	msg := fmt.Sprintf("%+v", fw_res)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type ShopPaymentServiceGenerator struct {
@@ -386,20 +397,22 @@ func (c *ShopPaymentServiceClient) GetGenerator() Generator {
 	return new(ShopPaymentServiceGenerator)
 }
 
-//
 // ------- ProductCatalog Service --------
-//
 type ShopProductCatalogServiceClient struct {
 	ClientBase
 	client pb.ProductCatalogServiceClient
 }
 
-func (c *ShopProductCatalogServiceClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *ShopProductCatalogServiceClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewProductCatalogServiceClient(c.conn)
+	return nil
 }
 
-func (c *ShopProductCatalogServiceClient) Request(ctx context.Context, req Input) string {
+func (c *ShopProductCatalogServiceClient) Request(ctx context.Context, req Input) (string, error) {
 
 	fw_method := req.Method
 	payload := req.Value
@@ -435,12 +448,12 @@ func (c *ShopProductCatalogServiceClient) Request(ctx context.Context, req Input
 		log.Fatalf("Failed to understand requested method: %s", fw_method)
 	}
 	if err != nil {
-		log.Fatalf("Fail to invoke ProductCatalog service: %v", err)
+		return "", err
 	}
 
 	msg = fmt.Sprintf("method: %s, %s", fw_method, msg)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type ShopProductCatalogServiceGenerator struct {
@@ -455,20 +468,22 @@ func (c *ShopProductCatalogServiceClient) GetGenerator() Generator {
 	return new(ShopProductCatalogServiceGenerator)
 }
 
-//
 // ------- Recommendation Service --------
-//
 type ShopRecommendationServiceClient struct {
 	ClientBase
 	client pb.RecommendationServiceClient
 }
 
-func (c *ShopRecommendationServiceClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *ShopRecommendationServiceClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewRecommendationServiceClient(c.conn)
+	return nil
 }
 
-func (c *ShopRecommendationServiceClient) Request(ctx context.Context, req Input) string {
+func (c *ShopRecommendationServiceClient) Request(ctx context.Context, req Input) (string, error) {
 
 	payload := req.Value
 	// Create a default forward request
@@ -479,11 +494,11 @@ func (c *ShopRecommendationServiceClient) Request(ctx context.Context, req Input
 
 	fw_res, err := c.client.ListRecommendations(ctx, &fw_req)
 	if err != nil {
-		log.Fatalf("Fail to invoke Recommendation service: %v", err)
+		return "", err
 	}
 	msg := fmt.Sprintf("%+v", fw_res)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type ShopRecommendationServiceGenerator struct {
@@ -498,20 +513,22 @@ func (c *ShopRecommendationServiceClient) GetGenerator() Generator {
 	return new(ShopRecommendationServiceGenerator)
 }
 
-//
 // ------- Shipping Service --------
-//
 type ShopShippingServiceClient struct {
 	ClientBase
 	client pb.ShippingServiceClient
 }
 
-func (c *ShopShippingServiceClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *ShopShippingServiceClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = pb.NewShippingServiceClient(c.conn)
+	return nil
 }
 
-func (c *ShopShippingServiceClient) Request(ctx context.Context, req Input) string {
+func (c *ShopShippingServiceClient) Request(ctx context.Context, req Input) (string, error) {
 
 	fw_method := req.Method
 
@@ -542,12 +559,12 @@ func (c *ShopShippingServiceClient) Request(ctx context.Context, req Input) stri
 		log.Fatalf("Failed to understand requested method: %s", fw_method)
 	}
 	if err != nil {
-		log.Fatalf("Fail to invoke Shipping service: %v", err)
+		return "", err
 	}
 
 	msg = fmt.Sprintf("method: %s, %s", fw_method, msg)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type ShopShippingServiceGenerator struct {

--- a/grpcclient/hotel_clients.go
+++ b/grpcclient/hotel_clients.go
@@ -18,7 +18,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//
 // Hotel reservation -----
 // 1. Geo service
 type HotelGeoClient struct {
@@ -26,12 +25,16 @@ type HotelGeoClient struct {
 	client geo.GeoClient
 }
 
-func (c *HotelGeoClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *HotelGeoClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = geo.NewGeoClient(c.conn)
+	return nil
 }
 
-func (c *HotelGeoClient) Request(ctx context.Context, req Input) string {
+func (c *HotelGeoClient) Request(ctx context.Context, req Input) (string, error) {
 	// Create a default forward request
 	coordinates := strings.Split(req.Value, ",")
 
@@ -45,12 +48,12 @@ func (c *HotelGeoClient) Request(ctx context.Context, req Input) string {
 
 	fw_res, err := c.client.Nearby(ctx, &fw_req)
 	if err != nil {
-		log.Fatalf("Fail to invoke Geo service: %v", err)
+		return "Fail to invoke Geo service", err
 	}
 
 	msg := fmt.Sprintf("req: { Lat:%f Lon:%f} resp: %+v", fw_req.Lon, fw_req.Lat, fw_res)
 	// log.Println(msg)
-	return msg
+	return msg, err
 }
 
 type HotelGeoGenerator struct {
@@ -87,12 +90,16 @@ type HotelProfileClient struct {
 	client profile.ProfileClient
 }
 
-func (c *HotelProfileClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *HotelProfileClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = profile.NewProfileClient(c.conn)
+	return nil
 }
 
-func (c *HotelProfileClient) Request(ctx context.Context, req Input) string {
+func (c *HotelProfileClient) Request(ctx context.Context, req Input) (string, error) {
 	payload := req.Value
 	ids := strings.Split(payload, ",")
 	// Create a forward request
@@ -103,12 +110,12 @@ func (c *HotelProfileClient) Request(ctx context.Context, req Input) string {
 
 	fw_res, err := c.client.GetProfiles(ctx, &fw_req)
 	if err != nil {
-		log.Fatalf("Fail to invoke Profile service: %v", err)
+		return "", err
 	}
 
 	msg := fmt.Sprintf("req: {HotelIds: %+v, Locale: \"\"} resp: %+v", ids, fw_res)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type HotelProfileGenerator struct {
@@ -150,12 +157,16 @@ type HotelRateClient struct {
 	client rate.RateClient
 }
 
-func (c *HotelRateClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *HotelRateClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = rate.NewRateClient(c.conn)
+	return nil
 }
 
-func (c *HotelRateClient) Request(ctx context.Context, req Input) string {
+func (c *HotelRateClient) Request(ctx context.Context, req Input) (string, error) {
 	payload := req.Value
 	ids := strings.Split(payload, ",")
 	// Create a forward request
@@ -166,12 +177,12 @@ func (c *HotelRateClient) Request(ctx context.Context, req Input) string {
 	}
 	fw_res, err := c.client.GetRates(ctx, &fw_req)
 	if err != nil {
-		log.Fatalf("Fail to invoke Rate service: %v", err)
+		return "", err
 	}
 
 	msg := fmt.Sprintf("req: {HotelIds: %+v, InDate: \"2015-04-09\", OutDate: \"2015-04-11\"}, resp: %+v", ids, fw_res)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type HotelRateGenerator struct {
@@ -204,12 +215,16 @@ type HotelRecommendationClient struct {
 	client recommendation.RecommendationClient
 }
 
-func (c *HotelRecommendationClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *HotelRecommendationClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = recommendation.NewRecommendationClient(c.conn)
+	return nil
 }
 
-func (c *HotelRecommendationClient) Request(ctx context.Context, req Input) string {
+func (c *HotelRecommendationClient) Request(ctx context.Context, req Input) (string, error) {
 
 	// Create a default forward request
 	coordinates := strings.Split(req.Value, ",")
@@ -232,12 +247,12 @@ func (c *HotelRecommendationClient) Request(ctx context.Context, req Input) stri
 
 	fw_res, err := c.client.GetRecommendations(ctx, &fw_req)
 	if err != nil {
-		log.Fatalf("Fail to invoke Recommendation service: %v", err)
+		return "", err
 	}
 
 	msg := fmt.Sprintf("req: {Require: \"dis\", Lat:%f Lon:%f}, resp: %+v", fw_req.Lon, fw_req.Lat, fw_res)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type HotelRecommendationGenerator struct {
@@ -268,12 +283,16 @@ type HotelReservationClient struct {
 	client reservation.ReservationClient
 }
 
-func (c *HotelReservationClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *HotelReservationClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = reservation.NewReservationClient(c.conn)
+	return nil
 }
 
-func (c *HotelReservationClient) Request(ctx context.Context, req Input) string {
+func (c *HotelReservationClient) Request(ctx context.Context, req Input) (string, error) {
 	fw_method := req.Method
 	payload := strings.Split(req.Value, ",")
 	// Create a default forward request
@@ -302,12 +321,12 @@ func (c *HotelReservationClient) Request(ctx context.Context, req Input) string 
 		log.Fatalf("Failed to understand requested method: %s", fw_method)
 	}
 	if err != nil {
-		log.Fatalf("Fail to invoke Reservation service: %v", err)
+		return "", err
 	}
 
 	msg := fmt.Sprintf("method: %s, req: {CustomerName: %s, HotelId: %v, InDate: \"2015-04-09\", OutDate: \"2015-04-11\", RoomNumber: 1,} resp: %+v", fw_method, fw_req.CustomerName, fw_req.HotelId, fw_res)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type HotelReservationGenerator struct {
@@ -345,12 +364,16 @@ type HotelUserClient struct {
 	client user.UserClient
 }
 
-func (c *HotelUserClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *HotelUserClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = user.NewUserClient(c.conn)
+	return nil
 }
 
-func (c *HotelUserClient) Request(ctx context.Context, req Input) string {
+func (c *HotelUserClient) Request(ctx context.Context, req Input) (string, error) {
 	payload := strings.Split(req.Value, ",")
 
 	// Create a forward request
@@ -361,12 +384,12 @@ func (c *HotelUserClient) Request(ctx context.Context, req Input) string {
 
 	fw_res, err := c.client.CheckUser(ctx, &fw_req)
 	if err != nil {
-		log.Fatalf("Fail to invoke User service: %v", err)
+		return "", err
 	}
 
 	msg := fmt.Sprintf("req: {Username: %s, Password: %s} resp: Correct:%v", fw_req.Username, fw_req.Password, fw_res.Correct)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type HotelUserGenerator struct {
@@ -404,12 +427,16 @@ type HotelSearchClient struct {
 	client search.SearchClient
 }
 
-func (c *HotelSearchClient) Init(ctx context.Context, ip, port string) {
-	c.Connect(ctx, ip, port)
+func (c *HotelSearchClient) Init(ctx context.Context, ip, port string) error {
+	err := c.Connect(ctx, ip, port)
+	if err != nil {
+		return err
+	}
 	c.client = search.NewSearchClient(c.conn)
+	return nil
 }
 
-func (c *HotelSearchClient) Request(ctx context.Context, req Input) string {
+func (c *HotelSearchClient) Request(ctx context.Context, req Input) (string, error) {
 	// Create a forward request
 	fw_req := search.NearbyRequest{
 		Lat:     37.7963,
@@ -420,12 +447,12 @@ func (c *HotelSearchClient) Request(ctx context.Context, req Input) string {
 
 	fw_res, err := c.client.Nearby(ctx, &fw_req)
 	if err != nil {
-		log.Fatalf("Fail to invoke Search service: %v", err)
+		return "", err
 	}
 
 	msg := fmt.Sprintf("req: {Lat: 37.7963, Lon: -122.4015, InDate: \"2015-04-09\", OutDate: \"2015-04-11\"}, resp: %+v", fw_res)
 	// log.Println(msg)
-	return msg
+	return msg, nil
 }
 
 type HotelSearchGenerator struct {


### PR DESCRIPTION
Instead of failing right away the grpcclient
returns an empty message and the error.
Now the client (relay) that implements the
grpcclient is responsibe to handle the error